### PR TITLE
Revert "CI: disable Python 3.10 and 3.11 tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,3 +51,5 @@ workflows:
     jobs:
       - build-python38
       - build-python39
+      - build-python310
+      - build-python311


### PR DESCRIPTION
This reverts commit a5c72be47fb3c7d102565f3ff3983115527a491c.