### PR TITLE
Add docker arg for base image and change labels

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: CD
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,13 +7,12 @@ on:
 
 jobs:
 
-  deploy:
-
+  build:
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
-   steps:
+    steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch: # run manually
+
+jobs:
+
+  deploy:
+
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        # we need tags for docker version tagging
+        fetch-tags: true
+        fetch-depth: 0
+    - # Activate cache export feature to reduce build time of images
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERIO_USERNAME }}
+        password: ${{ secrets.DOCKERIO_PASSWORD }}
+    - name: Build the Docker image
+      # build both tags at the same time
+      run: make docker DOCKER_TAG="docker.io/ocrd/kraken -t ghcr.io/ocr-d/kraken"
+    - name: Test the Docker image
+      run: docker run --rm ocrd/kraken ocrd-kraken-segment -h
+    - name: Push to Dockerhub
+      run: docker push docker.io/ocrd/kraken
+    - name: Push to Github Container Registry
+      run: docker push ghcr.io/ocr-d/kraken

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,12 @@
-FROM ocrd/core-cuda
+ARG DOCKER_BASE_IMAGE
+FROM $DOCKER_BASE_IMAGE
 ARG VCS_REF
 ARG BUILD_DATE
-MAINTAINER unixprog@gmail.com
-LABEL maintainer="https://ocr-d.de"
-LABEL org.label-schema.vendor="DFG-Funded Initiative for Optical Character Recognition Development"
-LABEL org.label-schema.name="ocrd_kraken"
-LABEL org.label-schema.vcs-ref=$VCS_REF
-LABEL org.label-schema.vcs-url="https://github.com/OCR-D/ocrd_kraken"
-LABEL org.label-schema.build-date=$BUILD_DATE
-LABEL org.opencontainers.image.vendor="DFG-Funded Initiative for Optical Character Recognition Development"
-LABEL org.opencontainers.image.title="ocrd_kraken"
-LABEL org.opencontainers.image.description="Kraken bindings"
-LABEL org.opencontainers.image.source="https://github.com/OCR-D/ocrd_kraken"
-LABEL org.opencontainers.image.documentation="https://github.com/OCR-D/ocrd_kraken/blob/${VCS_REF}/README.md"
-LABEL org.opencontainers.image.revision=$VCS_REF
-LABEL org.opencontainers.image.created=$BUILD_DATE
-LABEL org.opencontainers.image.base.name=ocrd/core-cuda
+LABEL \
+    maintainer="https://ocr-d.de/kontakt" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/OCR-D/ocrd_kraken" \
+    org.label-schema.build-date=$BUILD_DATE
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONIOENCODING utf8

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,15 @@ LABEL \
     maintainer="https://ocr-d.de/kontakt" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url="https://github.com/OCR-D/ocrd_kraken" \
-    org.label-schema.build-date=$BUILD_DATE
+    org.label-schema.build-date=$BUILD_DATE \
+    org.opencontainers.image.vendor="DFG-Funded Initiative for Optical Character Recognition Development" \
+    org.opencontainers.image.title="ocrd_kraken" \
+    org.opencontainers.image.description="Kraken bindings" \
+    org.opencontainers.image.source="https://github.com/OCR-D/ocrd_kraken" \
+    org.opencontainers.image.documentation="https://github.com/OCR-D/ocrd_kraken/blob/${VCS_REF}/README.md" \
+    org.opencontainers.image.revision=$VCS_REF \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.base.name=ocrd/core-cuda
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONIOENCODING utf8

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ PYTHONIOENCODING=utf8
 
 # Docker container tag ("$(DOCKER_TAG)")
 DOCKER_TAG = 'ocrd/kraken'
+DOCKER_BASE_IMAGE = docker.io/ocrd/core-cuda:v2.70.0
+
 
 # BEGIN-EVAL makefile-parser --make-help Makefile
 
@@ -62,8 +64,9 @@ build:
 # Build docker image
 docker:
 	docker build \
-        --build-arg VCS_REF=$$(git rev-parse --short HEAD) \
-        --build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
+	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
+	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
 	-t $(DOCKER_TAG) .
 
 # Run test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PYTHONIOENCODING=utf8
 
 # Docker container tag ("$(DOCKER_TAG)")
 DOCKER_TAG = 'ocrd/kraken'
-DOCKER_BASE_IMAGE = docker.io/ocrd/core-cuda:v2.70.0
+DOCKER_BASE_IMAGE = docker.io/ocrd/core-cuda-torch:v2.70.0
 
 
 # BEGIN-EVAL makefile-parser --make-help Makefile


### PR DESCRIPTION
This adds an argument for the baseimage to the Dockerfile and changes the docker target in the Makefile accordingly. Like it was done for the other processors.

I am not sure about the labels. Here many labels were available, other what we have for the other processors, were only 4 labels are set. I simply removed all the labels to make it consistent (exect the usual 4 labels) . But I am not sure if this is right so maybe this has to be changed again. Therefore this is only a draft yet.